### PR TITLE
 fix/slack-blacklisted-channel-ids

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-VERSION = "0.3.36"
+VERSION = "0.3.37"
 
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
Fix Slack scan for blacklisted channel IDs during org-wide scan